### PR TITLE
Fix icon overlay shift indices for mod compatibility

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 0.2.2
 Date: ????
   Changes:
+    - Changed icon overlay shift to use [1] and [2] indices (resolves error with long range delivery drones mod)
 ---------------------------------------------------------------------------------------------------
 Version: 0.2.1
 Date: 2025-10-10

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -47,10 +47,16 @@ local function add_overlay_to_icon(item, sprite, corner, inset_fraction, inset_p
     if sprite.width and sprite.height then
         overlay_icon_size = math.max(sprite.width, sprite.height)
     elseif sprite.size then
-        ---@type number
-        overlay_icon_size = type(sprite.size) == "number" and sprite.size or math.max(sprite.size[1], sprite.size[2])
-    else
-        overlay_icon_size = base_icon_size
+        if type(sprite.size) == "number" then
+            overlay_icon_size = sprite.size ---@type number
+        elseif type(sprite.size) == "table"
+            and type(sprite.size[1]) == "number"
+            and type(sprite.size[2]) == "number"
+        then
+            overlay_icon_size = math.max(sprite.size[1], sprite.size[2])
+        else
+            overlay_icon_size = base_icon_size
+        end
     end
 
     ---@type data.IconData overlay definition

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -47,18 +47,19 @@ local function add_overlay_to_icon(item, sprite, corner, inset_fraction, inset_p
     if sprite.width and sprite.height then
         overlay_icon_size = math.max(sprite.width, sprite.height)
     elseif sprite.size then
-        overlay_icon_size = sprite.size
+        ---@type number
+        overlay_icon_size = type(sprite.size) == "number" and sprite.size or math.max(sprite.size[1], sprite.size[2])
     else
         overlay_icon_size = base_icon_size
     end
 
-    -- overlay definition
+    ---@type data.IconData overlay definition
     local overlay = {
         icon      = sprite.filename,
         icon_size = overlay_icon_size,
         scale     = overlay_scale,
         floating  = true,
-        shift     = { x = mul[1] * px, y = mul[2] * px },
+        shift     = { mul[1] * px, mul[2] * px },
     }
 
     -- convert single icon → icons[] if necessary

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -49,9 +49,11 @@ local function add_overlay_to_icon(item, sprite, corner, inset_fraction, inset_p
     elseif sprite.size then
         if type(sprite.size) == "number" then
             overlay_icon_size = sprite.size ---@type number
-        elseif type(sprite.size) == "table"
+        elseif (
+            type(sprite.size) == "table"
             and type(sprite.size[1]) == "number"
             and type(sprite.size[2]) == "number"
+        )
         then
             overlay_icon_size = math.max(sprite.size[1], sprite.size[2])
         else


### PR DESCRIPTION
Updated icon overlay shift to use [1] and [2] indices instead of x/y keys, resolving errors with the long range delivery drones mod. Also improved overlay icon size calculation for array-based sprite sizes.